### PR TITLE
Preserve data in the browser

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,7 +143,6 @@
           class="form"
           id="form-contact"
         >
-          <div class="field">
             <label for="name" hidden>Name</label>
             <input
               type="text"
@@ -154,9 +153,6 @@
               maxlength="30"
               required
             />
-            <small></small>
-          </div>
-          <div class="field">
             <label for="email" hidden>Email</label>
             <input
               type="email"
@@ -165,22 +161,19 @@
               name="email"
               placeholder="Your email"
             />
-            <small></small>
-          </div>
           <label for="message" hidden>Message</label>
           <textarea
             id="message"
             class="contact-form-message input-hover"
             name="message"
             placeholder="Enter your message here.."
-            id=""
             cols="30"
             rows="10"
             maxlength="500"
             required
           ></textarea>
           <div class="contact-button">
-            <button class="button-start-collaboration" type="submit">
+            <button class="button-start-collaboration" type="submit" id="formButton">
               Start collaboration
             </button>
             <div id="errorm"></div>

--- a/script.js
+++ b/script.js
@@ -471,3 +471,11 @@ form.addEventListener('submit', (event) => {
     alert('Form submitted');
   }
 });
+
+const nameInput = document.querySelector('#name');
+nameInput.value = JSON.parse(localStorage.getItem('form')).name;
+nameInput.addEventListener('input', (name) => {
+  const objForm = JSON.parse(localStorage.getItem('form'));
+  objForm.name = name.target.value;
+  localStorage.setItem('form', JSON.stringify(objForm));
+});

--- a/script.js
+++ b/script.js
@@ -473,9 +473,25 @@ form.addEventListener('submit', (event) => {
 });
 
 const nameInput = document.querySelector('#name');
-nameInput.value = JSON.parse(localStorage.getItem('form')).name;
+nameInput.value = JSON.parse(localStorage.getItem('form'))?.name || '';
 nameInput.addEventListener('input', (name) => {
-  const objForm = JSON.parse(localStorage.getItem('form'));
+  const objForm = JSON.parse(localStorage.getItem('form')) || { name: '', email: '', message: '' };
   objForm.name = name.target.value;
+  localStorage.setItem('form', JSON.stringify(objForm));
+});
+
+const mailInput = document.querySelector('#email');
+mailInput.value = JSON.parse(localStorage.getItem('form'))?.email || '';
+mailInput.addEventListener('input', (email) => {
+  const objForm = JSON.parse(localStorage.getItem('form')) || { name: '', email: '', message: '' };
+  objForm.email = email.target.value;
+  localStorage.setItem('form', JSON.stringify(objForm));
+});
+
+const textAreaInput = document.querySelector('#message');
+textAreaInput.value = JSON.parse(localStorage.getItem('form'))?.message || '';
+textAreaInput.addEventListener('input', (message) => {
+  const objForm = JSON.parse(localStorage.getItem('form')) || { name: '', email: '', message: '' };
+  objForm.message = message.target.value;
   localStorage.setItem('form', JSON.stringify(objForm));
 });


### PR DESCRIPTION
My partner and I implement the following interactions:

- When the user changes the content of any input field, the data is saved to the local storage.
- When the user loads the page, if there is any data in the local storage the input fields are pre-filled with this data.
- Create a single JavaScript object with all the data from the entire form and save it in local storage. Do not create one local storage entry per input field.